### PR TITLE
Missed one internal call that the NetworkManager uses

### DIFF
--- a/Assets/Mirror/Runtime/ClientScene.cs
+++ b/Assets/Mirror/Runtime/ClientScene.cs
@@ -50,7 +50,7 @@ namespace Mirror
         /// <para>This is read-only. To change the ready state of a client, use ClientScene.Ready(). The server is able to set the ready state of clients using NetworkServer.SetClientReady(), NetworkServer.SetClientNotReady() and NetworkServer.SetAllClientsNotReady().</para>
         /// <para>This is done when changing scenes so that clients don't receive state update messages during scene loading.</para>
         /// </summary>
-        public static bool ready { get; internal set; }
+        public static bool ready { get; set; }
 
         /// <summary>
         /// The NetworkConnection object that is currently "ready". This is the connection to the server where objects are spawned from.


### PR DESCRIPTION
This is called in the NetworkManager and in doing the work to make a fully custom NetworkManager - as i talked about in #2039 I found i needed to call this on the NetworkClient.RegisterHandler<NotReadyMessage> callback - as you can see here https://github.com/vis2k/Mirror/blob/master/Assets/Mirror/Runtime/NetworkManager.cs#L1265

Honestly though walking the code for this is a very weird situation where `NetworkServer.SetClientNotReady()` which sends a `NotReadyMessage` message to the client which it then eventually in `NetworkManager` calls `ClientScene.ready = false` feels very weird to me because the other side of things has a dedicated function ClientScene.Ready() - so it feels like there should be a ClientScene.NotReady() and the property should be left as is.

Likely not something to fix here and now - but i need this setter to not be internal so i can continue making a fully custom NetworkManager without inheriting.